### PR TITLE
Fix compatibility with version 1.0 of ramazancetinkaya/byte-formatter

### DIFF
--- a/src/AbstractEvictStrategy.php
+++ b/src/AbstractEvictStrategy.php
@@ -44,6 +44,6 @@ abstract class AbstractEvictStrategy
     {
         // in case the library broke, we can refer to this link: https://stackoverflow.com/questions/15188033/human-readable-file-size
         $formatter = new ByteFormatter();
-        return $formatter->format($bytes);
+        return $formatter->formatBytes($bytes);
     }
 }


### PR DESCRIPTION
The byte formatting function was [recently renamed from `format` to `formatBytes`](https://github.com/ramazancetinkaya/byte-formatter/commit/ffdaa182cd3975ad15815f996cdd60acf0155814), and then [a version 1.0.0 was tagged](https://github.com/ramazancetinkaya/byte-formatter/releases/tag/1.0.0). This breaks this library, which had declared a package dependency on version 1.0 (which did not exist yet), but also assumed the old function name.

This commit restores compatibility by using the new function name.