### PR TITLE
Adopt Laravel's Number::fileSize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note: you may refer to `README.md` for description of features.
 ## Dev (WIP)
 
 ## 2.0.0 (2025-01-12)
-- Adopted Laravel's `Number::fileSize()` to show the estimated file size cleaned stats
+- Adopted Laravel's `Number::fileSize()` to show the estimated storage size cleaned stats
   - Therefore, further requires `ext-intl`
 
 ## 1.0.3 (2025-01-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note: you may refer to `README.md` for description of features.
 ## Dev (WIP)
 
 ## 2.0.0 (2025-01-12)
-- Adopted Laravel's `Number::fileSize()` to show the estimated storage size cleaned stats
+- Adopted Laravel's `Number::fileSize()` to show the estimated evicted storage size stats
   - Therefore, further requires `ext-intl`
 
 ## 1.0.3 (2025-01-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ Note: you may refer to `README.md` for description of features.
 
 ## Dev (WIP)
 
-## 1.0.3 (2025-01-17)
+## 2.0.0 (2025-01-12)
+- Adopted Laravel's `Number::fileSize()` to show the estimated file size cleaned stats
+  - Therefore, further requires `ext-intl`
+
+## 1.0.3 (2025-01-07)
 Special note: this update is made in response to the external rugpull as discovered in #4. All previous versions are "tainted" and will not be supported, effective immediately. Update your installed version now!!!
 - No longer depends on `ramazancetinkaya/byte-formatter` as culprit of rugpull
   - A StackOverflow-copied solution is being used for now
@@ -26,4 +30,3 @@ This is a utility library for Laravel that can efficiently remove many expired c
 - Supports the `file` and `database` cache driver
 - Supports self-defined cache eviction strategies
 - Uses PHP generators to avoid using too much memory while scanning for expired items
-

--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,8 @@
                 "Vectorial1024\\LaravelCacheEvict\\CacheEvictServiceProvider"
             ]
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "ext-intl": "*",
         "illuminate/support": "^10.0|^11.0",
         "wilderborn/partyline": "^1.0"
     },

--- a/src/AbstractEvictStrategy.php
+++ b/src/AbstractEvictStrategy.php
@@ -3,6 +3,7 @@
 namespace Vectorial1024\LaravelCacheEvict;
 
 use Illuminate\Console\OutputStyle;
+use Illuminate\Support\Number;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -41,10 +42,7 @@ abstract class AbstractEvictStrategy
      */
     protected function bytesToHuman(int $bytes): string
     {
-        // the guy did a rugpull; the link turned out to be very handy.
-        // see https://stackoverflow.com/questions/15188033/human-readable-file-size
-        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
-        for ($i = 0; $bytes > 1024; $i++) $bytes /= 1024;
-        return round($bytes, 2) . ' ' . $units[$i];
+        // it turns out Laravel already has a helper for this
+        return Number::fileSize($bytes, 2, 2);
     }
 }


### PR DESCRIPTION
It turns out, this helper is only available in Laravel 10, which is coincidentally the minimum requirements of this library. But then, using it requires a new PHP extension, which will break existing builds.

As such, to respect semver, the major version will be bumped. We don't do rugpulls here.