### PR TITLE
Database Evictor: explicitly require primary key ASC ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Note: you may refer to `README.md` for description of features.
 
 ## Dev (WIP)
+- Fixed database cache evictor stopping midway while iterating through the cache table
+  - This problem was seen on PostgreSQL (see #11), but perhaps some other database engines are also affected
 
 ## 2.0.5
 - Improved database cache evictor handling of cache prefix

--- a/src/Database/DatabaseEvictStrategy.php
+++ b/src/Database/DatabaseEvictStrategy.php
@@ -128,6 +128,8 @@ class DatabaseEvictStrategy extends AbstractEvictStrategy
                 ->select(['key', 'expiration', DB::raw('LENGTH(key) AS key_bytes'), DB::raw('LENGTH(value) AS value_bytes')])
                 ->where('key', '>', $currentActualKey)
                 ->where(DB::raw("SUBSTRING(key, 1, $prefixLength)"), '=', $cachePrefix)
+                // PostgreSQL: if no sorting specified, then will ignore primary key index/ordering, which breaks the intended workflow
+                ->orderBy('key')
                 ->limit(1)
                 ->first();
             if (!$record) {


### PR DESCRIPTION
This finally fixes #11 